### PR TITLE
Add #define clause for BLACKPILL

### DIFF
--- a/examples/bluepill_test/bluepill_test.c
+++ b/examples/bluepill_test/bluepill_test.c
@@ -1,15 +1,27 @@
 #include <libopencm3/stm32/rcc.h>
 #include <libopencm3/stm32/gpio.h>
 
+#define BLACKPILL
+
+#ifdef BLACKPILL
+	#define RCC_GPIOX RCC_GPIOB
+        #define GPIOX GPIOB
+        #define GPION GPIO12
+#else
+	#define RCC_GPIOX RCC_GPIOC
+	#define GPIOX GPIOC
+	#define GPION GPIO13
+#endif
+
 int main(void) {
-    rcc_periph_clock_enable(RCC_GPIOC);
-    gpio_set_mode(GPIOC, GPIO_MODE_OUTPUT_2_MHZ, GPIO_CNF_OUTPUT_PUSHPULL,
-                  GPIO13);
+    rcc_periph_clock_enable(RCC_GPIOX);
+    gpio_set_mode(GPIOX, GPIO_MODE_OUTPUT_2_MHZ, GPIO_CNF_OUTPUT_PUSHPULL,
+                  GPION);
 
     while(1) {
-        gpio_set(GPIOC, GPIO13);
+        gpio_set(GPIOX, GPION);
         for (int i = 0; i < 100000; ++i) __asm__("nop");
-        gpio_clear(GPIOC, GPIO13);
+        gpio_clear(GPIOX, GPION);
         for (int i = 0; i <  100000; ++i) __asm__("nop");
     }
 }


### PR DESCRIPTION
BLACKPILL board has the onboard LED on PB12 instead of PC13. This modification allows to use the blink example with a BLACKPILL changing a #define.