### PR TITLE
Add #define clause for BLACKPILL

### DIFF
--- a/examples/usart_rxtx_test/usart_test.c
+++ b/examples/usart_rxtx_test/usart_test.c
@@ -2,12 +2,24 @@
 #include <libopencm3/stm32/gpio.h>
 #include <libopencm3/stm32/usart.h>
 
+//#define BLACKPILL
+
+#ifdef BLACKPILL
+        #define RCC_GPIOX RCC_GPIOB
+        #define GPIOX GPIOB
+        #define GPION GPIO12
+#else
+        #define RCC_GPIOX RCC_GPIOC
+        #define GPIOX GPIOC
+        #define GPION GPIO13
+#endif
+
 static void clock_setup(void) {
     rcc_clock_setup_in_hse_8mhz_out_72mhz();
 
     /* Enable GPIOC clock. */
     rcc_periph_clock_enable(RCC_GPIOA);
-    rcc_periph_clock_enable(RCC_GPIOC);
+    rcc_periph_clock_enable(RCC_GPIOX);
 
     /* Enable clocks for GPIO port B (for GPIO_USART3_TX) and USART3. */
     rcc_periph_clock_enable(RCC_USART1);
@@ -34,8 +46,8 @@ static void usart_setup(void) {
 
 static void gpio_setup(void) {
     /* Set GPIO12 (in GPIO port C) to 'output push-pull'. */
-    gpio_set_mode(GPIOC, GPIO_MODE_OUTPUT_2_MHZ, GPIO_CNF_OUTPUT_PUSHPULL,
-            GPIO13);
+    gpio_set_mode(GPIOX, GPIO_MODE_OUTPUT_2_MHZ, GPIO_CNF_OUTPUT_PUSHPULL,
+            GPION);
 }
 
 char welcome[] = "Echo test\n";
@@ -50,8 +62,7 @@ int main(void) {
         usart_send_blocking(USART1, welcome[i]);
     }
     while (1) {
-        gpio_toggle(GPIOC, GPIO13); /* LED on/off */
+        gpio_toggle(GPIOX, GPION); /* LED on/off */
         usart_send_blocking(USART1, usart_recv_blocking(USART1));
     }
 }
-


### PR DESCRIPTION
BLACKPILL board has the onboard LED on PB12 instead of PC13. This modification allows to use the blink example with a BLACKPILL changing a #define.