### PR TITLE
Fix USART1 configuration issues in two examples.

### DIFF
--- a/examples/sensor_test/sensor_test.c
+++ b/examples/sensor_test/sensor_test.c
@@ -65,10 +65,10 @@ static void usart_setup(void)
 
     /* Setup UART parameters. */
     usart_set_baudrate(USART1, 115200);
-    usart_set_databits(USART1, 8);
+    usart_set_databits(USART1, 9);
     usart_set_stopbits(USART1, USART_STOPBITS_1);
     usart_set_mode(USART1, USART_MODE_TX);
-    usart_set_parity(USART1, USART_PARITY_NONE);
+    usart_set_parity(USART1, USART_PARITY_EVEN);
     usart_set_flow_control(USART1, USART_FLOWCONTROL_NONE);
 
     /* Finally enable the USART. */

--- a/examples/usart_tx_test/usart_test.c
+++ b/examples/usart_tx_test/usart_test.c
@@ -41,11 +41,11 @@ static void usart_setup(void)
               GPIO_CNF_OUTPUT_ALTFN_PUSHPULL, GPIO_USART1_TX);
 
     /* Setup UART parameters. */
-    usart_set_baudrate(USART1, 38400);
-    usart_set_databits(USART1, 8);
+    usart_set_baudrate(USART1, 115200);
+    usart_set_databits(USART1, 9);
     usart_set_stopbits(USART1, USART_STOPBITS_1);
     usart_set_mode(USART1, USART_MODE_TX);
-    usart_set_parity(USART1, USART_PARITY_NONE);
+    usart_set_parity(USART1, USART_PARITY_EVEN);
     usart_set_flow_control(USART1, USART_FLOWCONTROL_NONE);
 
     /* Finally enable the USART. */


### PR DESCRIPTION
Some of the examples were not updated to the current USART configuration so they were not compatible with our current HC05 configuration.