### PR TITLE
Move development tools to Docker container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,14 @@ RUN mkdir /home/src
 
 WORKDIR /home/src
 
-RUN useradd -ms /bin/bash mightyteam && adduser mightyteam plugdev
+ARG UID=1000
+ARG GID=1000
+RUN groupadd -g $GID -o mightyteam
+RUN useradd -m -u $UID -g $GID -o -s /bin/bash mightyteam
+
+RUN usermod -a -G dialout mightyteam
+RUN usermod -a -G plugdev mightyteam
+
 USER mightyteam
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+FROM debian:stretch-slim
+
+RUN apt-get update && apt-get install -y \
+  make \
+  python \
+  python-serial \
+  wget \
+  tar \
+&& rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt
+
+#RUN pip --no-cache-dir install pyserial
+
+#RUN wget "https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2018q4/gcc-arm-none-eabi-8-2018-q4-major-linux.tar.bz2?revision=d830f9dd-cd4f-406d-8672-cca9210dd220?product=GNU%20Arm%20Embedded%20Toolchain,64-bit,,Linux,8-2018-q4-major" -O temp.tar.bz2 \
+RUN wget "https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2?revision=bc2c96c0-14b5-4bb4-9f18-bceb4050fee7?product=GNU%20Arm%20Embedded%20Toolchain,64-bit,,Linux,7-2018-q2-update" -O temp.tar.bz2 \
+#RUN wget "https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2017q4/gcc-arm-none-eabi-7-2017-q4-major-linux.tar.bz2?revision=375265d4-e9b5-41c8-bf23-56cbe927e156?product=GNU%20Arm%20Embedded%20Toolchain,64-bit,,Linux,7-2017-q4-major" -O temp.tar.bz2 \
+&& tar -xvjf temp.tar.bz2 \
+&& rm -rf temp.tar.bz2
+
+RUN mkdir /opt/stm32loader/ && \
+    cd /opt/stm32loader/ && \
+    wget https://raw.githubusercontent.com/jsnyder/stm32loader/master/stm32loader.py && \
+    chmod +x /opt/stm32loader/stm32loader.py && \
+    ln -s /opt/stm32loader/stm32loader.py /usr/local/bin/stm32loader
+
+#ENV PATH="/opt/gcc-arm-none-eabi-8-2018-q4-major/bin:${PATH}"
+ENV PATH="/opt/gcc-arm-none-eabi-7-2018-q2-update/bin:${PATH}"
+#ENV PATH="/opt/gcc-arm-none-eabi-7-2017-q4-major/bin:${PATH}"
+
+RUN mkdir /home/src
+
+WORKDIR /home/src
+
+RUN useradd -ms /bin/bash mightyteam && adduser mightyteam plugdev
+USER mightyteam
+
+
+#ENTRYPOINT ["make", "-C"]
+
+#CMD ["./", "all"]

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,9 @@ PORT = /dev/ttyUSB0
 EXAMPLE = bluepill_test
 
 build_image:
-	docker build -t $(DOCKER_IMAGE_NAME) .
+	docker build --build-arg UID=$(id -u) \
+		--build-arg GID=$(id -g) \
+		-t $(DOCKER_IMAGE_NAME) .
 
 rm_image:
 	docker rmi -f $(DOCKER_IMAGE_NAME)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,76 @@
+VERSION_NAME=electronic_experience
+BIN_PATH=./bin
+
+CSRC = $(wildcard *.c)
+OBJ_NO_DIR = $(CSRC:%.c=%.o)
+OBJ = $(patsubst %.c,$(BIN_PATH)/%.o,$(CSRC))
+
+DOCKER_IMAGE_NAME = mighty-arm-development
+PORT = /dev/ttyUSB0
+EXAMPLE = bluepill_test
+
+build_image:
+	docker build -t $(DOCKER_IMAGE_NAME) .
+
+rm_image:
+	docker rmi -f $(DOCKER_IMAGE_NAME)
+
+console:
+	docker run -v $(PWD):/home/src/ \
+		-ti \
+		--rm \
+		--device=/dev/ttyUSB0 \
+		$(DOCKER_IMAGE_NAME)
+
+buga_fw: ## Build line follower firmware at src/mightybug_a
+	docker run -v $(PWD):/home/src/ \
+		-ti \
+		--rm \
+		$(DOCKER_IMAGE_NAME) \
+		make -C src/mightybug_a/ clean all
+
+buga_fw_flash: ## Flash firmware to the board at PORT (default: /dev/ttyUSB0). Example: make buga_fw_flash PORT=/dev/ttyUSB3
+	docker run -v $(PWD):/home/src/ \
+		-ti \
+		--rm \
+		--device=$(PORT) \
+		$(DOCKER_IMAGE_NAME) \
+		stm32loader -p $(PORT) -e -w -V -g 0x08000000 -v src/mightybug_a/bin/electronic_experience.bin
+
+EXAMPLES := $(sort $(wildcard examples/*))
+FLASH := $(addsuffix _flash, $(EXAMPLES))
+
+$(EXAMPLES): BINARY = $(subst examples/,,$@)
+$(EXAMPLES):
+	docker run -v $(PWD):/home/src/ \
+		-ti \
+		--rm \
+		$(DOCKER_IMAGE_NAME) \
+		make -C $@ clean all BIN=$(BINARY)
+
+$(FLASH): FOLDER = $(subst _flash,,$@)
+$(FLASH): BINARY = $(subst examples/,,$(FOLDER))
+$(FLASH):
+	docker run -v $(PWD):/home/src/ \
+		-ti \
+		--rm \
+		--device=$(PORT) \
+		$(DOCKER_IMAGE_NAME) \
+		stm32loader -p $(PORT) -e -w -V -g 0x08000000 -v $(FOLDER)/$(BINARY).bin
+
+.PHONY: $(EXAMPLES) $(FLASH)
+
+help:
+	@printf '\033[33mBase targets:\033[0m\n'
+	@printf '\033[36m    %-25s\033[0m %s\n' 'build_image' 'Generate Docker development image. Includes ARM GCC toolchain and stm32loader.'
+	@printf '\033[36m    %-25s\033[0m %s\n' 'rm_image' 'Delete Docker development image.'
+	@printf '\033[36m    %-25s\033[0m %s\n' 'console' 'Run Docker container with an interactive bash terminal'
+	@printf '\033[36m    %-25s\033[0m %s\n' 'buga_fw' 'Build line follower firwmare at src/mightybug_a.'
+	@printf '\033[36m    %-25s\033[0m %s\n' 'buga_fw_flash' 'Load firmware to the board connected to PORT (default: /dev/ttyUSB0). Example: make buga_fw_flash PORT=/dev/ttyUSB3'
+	@printf '\n'
+	@printf '\033[33m%-29s\033[0m Targets to build each example. Add \033[36m"_flash"\033[0m suffix to load the corresponding example to the board\n' 'Examples:'
+	@for v in $(EXAMPLES) ; do \
+		printf '\033[36m    %s\033[0m\n' $$v; \
+    done
+
+.DEFAULT_GOAL := help

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ PORT = /dev/ttyUSB0
 EXAMPLE = bluepill_test
 
 build_image:
-	docker build --build-arg UID=$(id -u) \
-		--build-arg GID=$(id -g) \
+	docker build --build-arg UID=$(shell id -u) \
+		--build-arg GID=$(shell id -g) \
 		-t $(DOCKER_IMAGE_NAME) .
 
 rm_image:
@@ -21,7 +21,7 @@ console:
 	docker run -v $(PWD):/home/src/ \
 		-ti \
 		--rm \
-		--device=/dev/ttyUSB0 \
+		--device=$(PORT) \
 		$(DOCKER_IMAGE_NAME)
 
 buga_fw: ## Build line follower firmware at src/mightybug_a

--- a/examples/bluepill_test/Makefile
+++ b/examples/bluepill_test/Makefile
@@ -1,10 +1,12 @@
 sinclude ../../rules.mk
 
 
-CSRC = bluepill_test.c
+CSRC = $(wildcard *.c)
 OBJ = $(CSRC:.c=.o)
 
-bluepill_test.elf: $(OBJ)
+BIN = bluepill_test
+
+$(BIN).elf: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 .PHONY: clean
@@ -16,10 +18,9 @@ clean_all:
 	-$(MAKE) -C libopencm3 clean
 
 
-%.bin: %.elf
+$(BIN).bin: $(BIN).elf
 	$(OBJCOPY) -O binary $< $@
 
-bin: bluepill_test.bin
+bin: $(BIN).bin
 
-all: libopencm3 bluepill_test.bin
-
+all: libopencm3 $(BIN).bin

--- a/examples/buzzer/Makefile
+++ b/examples/buzzer/Makefile
@@ -1,10 +1,12 @@
 sinclude ../../rules.mk
 
 
-CSRC = buzzer.c
+CSRC = $(wildcard *.c)
 OBJ = $(CSRC:.c=.o)
 
-buzzer.elf: $(OBJ)
+BIN = buzzer
+
+$(BIN).elf: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 .PHONY: clean
@@ -16,9 +18,9 @@ clean_all:
 	-$(MAKE) -C libopencm3 clean
 
 
-%.bin: %.elf
+$(BIN).bin: $(BIN).elf
 	$(OBJCOPY) -O binary $< $@
 
-bin: buzzer.bin
+bin: $(BIN).bin
 
-all: libopencm3 buzzer.bin
+all: libopencm3 $(BIN).bin

--- a/examples/buzzer_jukebox/Makefile
+++ b/examples/buzzer_jukebox/Makefile
@@ -4,7 +4,9 @@ sinclude ../../rules.mk
 CSRC = $(wildcard *.c)
 OBJ = $(CSRC:.c=.o)
 
-buzzer.elf: $(OBJ)
+BIN = buzzer_jukebox
+
+$(BIN).elf: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 .PHONY: clean
@@ -16,9 +18,9 @@ clean_all:
 	-$(MAKE) -C libopencm3 clean
 
 
-%.bin: %.elf
+$(BIN).bin: $(BIN).elf
 	$(OBJCOPY) -O binary $< $@
 
-bin: buzzer.bin
+bin: $(BIN).bin
 
-all: libopencm3 buzzer.bin
+all: libopencm3 $(BIN).bin

--- a/examples/buzzer_music/Makefile
+++ b/examples/buzzer_music/Makefile
@@ -1,10 +1,12 @@
 sinclude ../../rules.mk
 
 
-CSRC = buzzer.c
+CSRC = $(wildcard *.c)
 OBJ = $(CSRC:.c=.o)
 
-buzzer.elf: $(OBJ)
+BIN = buzzer_music
+
+$(BIN).elf: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 .PHONY: clean
@@ -16,9 +18,9 @@ clean_all:
 	-$(MAKE) -C libopencm3 clean
 
 
-%.bin: %.elf
+$(BIN).bin: $(BIN).elf
 	$(OBJCOPY) -O binary $< $@
 
-bin: buzzer.bin
+bin: $(BIN).bin
 
-all: libopencm3 buzzer.bin
+all: libopencm3 $(BIN).bin

--- a/examples/cli_test/Makefile
+++ b/examples/cli_test/Makefile
@@ -1,10 +1,12 @@
 sinclude ../../rules.mk
 
 
-CSRC = cli_test.c
+CSRC = $(wildcard *.c)
 OBJ = $(CSRC:.c=.o)
 
-cli_test.elf: $(OBJ)
+BIN = cli_test
+
+$(BIN).elf: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 .PHONY: clean
@@ -16,10 +18,9 @@ clean_all:
 	-$(MAKE) -C libopencm3 clean
 
 
-%.bin: %.elf
+$(BIN).bin: $(BIN).elf
 	$(OBJCOPY) -O binary $< $@
 
-bin: cli_test.bin
+bin: $(BIN).bin
 
-all: libopencm3 cli_test.bin
-
+all: libopencm3 $(BIN).bin

--- a/examples/dma_usart_rxtx_pingpong/Makefile
+++ b/examples/dma_usart_rxtx_pingpong/Makefile
@@ -4,7 +4,9 @@ sinclude ../../rules.mk
 CSRC = $(wildcard *.c)
 OBJ = $(CSRC:.c=.o)
 
-dma_usart_test.elf: $(OBJ)
+BIN = dma_usart_rxtx_pingpong
+
+$(BIN).elf: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 .PHONY: clean
@@ -16,10 +18,9 @@ clean_all:
 	-$(MAKE) -C libopencm3 clean
 
 
-%.bin: %.elf
+$(BIN).bin: $(BIN).elf
 	$(OBJCOPY) -O binary $< $@
 
-bin: dma_usart_test.bin
+bin: $(BIN).bin
 
-all: libopencm3 dma_usart_test.bin
-
+all: libopencm3 $(BIN).bin

--- a/examples/encoder_without_timer/Makefile
+++ b/examples/encoder_without_timer/Makefile
@@ -4,7 +4,9 @@ sinclude ../../rules.mk
 CSRC = $(wildcard *.c)
 OBJ = $(CSRC:.c=.o)
 
-main.elf: $(OBJ)
+BIN = encoder_without_timer
+
+$(BIN).elf: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 .PHONY: clean
@@ -16,10 +18,9 @@ clean_all:
 	-$(MAKE) -C libopencm3 clean
 
 
-%.bin: %.elf
+$(BIN).bin: $(BIN).elf
 	$(OBJCOPY) -O binary $< $@
 
-bin: main.bin
+bin: $(BIN).bin
 
-all: libopencm3 main.bin
-
+all: libopencm3 $(BIN).bin

--- a/examples/encoder_without_timer_share_isr/Makefile
+++ b/examples/encoder_without_timer_share_isr/Makefile
@@ -4,7 +4,9 @@ sinclude ../../rules.mk
 CSRC = $(wildcard *.c)
 OBJ = $(CSRC:.c=.o)
 
-main.elf: $(OBJ)
+BIN = encoder_without_timer_share_isr
+
+$(BIN).elf: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 .PHONY: clean
@@ -16,10 +18,9 @@ clean_all:
 	-$(MAKE) -C libopencm3 clean
 
 
-%.bin: %.elf
+$(BIN).bin: $(BIN).elf
 	$(OBJCOPY) -O binary $< $@
 
-bin: main.bin
+bin: $(BIN).bin
 
-all: libopencm3 main.bin
-
+all: libopencm3 $(BIN).bin

--- a/examples/example_structure_with_cli/Makefile
+++ b/examples/example_structure_with_cli/Makefile
@@ -4,7 +4,9 @@ sinclude ../../rules.mk
 CSRC = $(wildcard *.c)
 OBJ = $(CSRC:.c=.o)
 
-main.elf: $(OBJ)
+BIN = example_structure_with_cli
+
+$(BIN).elf: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 .PHONY: clean
@@ -16,10 +18,9 @@ clean_all:
 	-$(MAKE) -C libopencm3 clean
 
 
-%.bin: %.elf
+$(BIN).bin: $(BIN).elf
 	$(OBJCOPY) -O binary $< $@
 
-bin: main.bin
+bin: $(BIN).bin
 
-all: libopencm3 main.bin
-
+all: libopencm3 $(BIN).bin

--- a/examples/flash_structured_data_rw/Makefile
+++ b/examples/flash_structured_data_rw/Makefile
@@ -4,7 +4,9 @@ sinclude ../../rules.mk
 CSRC = $(wildcard *.c)
 OBJ = $(CSRC:.c=.o)
 
-main.elf: $(OBJ)
+BIN = flash_structured_data_rw
+
+$(BIN).elf: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 .PHONY: clean
@@ -16,10 +18,9 @@ clean_all:
 	-$(MAKE) -C libopencm3 clean
 
 
-%.bin: %.elf
+$(BIN).bin: $(BIN).elf
 	$(OBJCOPY) -O binary $< $@
 
-bin: main.bin
+bin: $(BIN).bin
 
-all: libopencm3 main.bin
-
+all: libopencm3 $(BIN).bin

--- a/examples/i2c_test/Makefile
+++ b/examples/i2c_test/Makefile
@@ -4,7 +4,9 @@ sinclude ../../rules.mk
 CSRC = $(wildcard *.c)
 OBJ = $(CSRC:.c=.o)
 
-main.elf: $(OBJ)
+BIN = i2c_test
+
+$(BIN).elf: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 .PHONY: clean
@@ -16,10 +18,9 @@ clean_all:
 	-$(MAKE) -C libopencm3 clean
 
 
-%.bin: %.elf
+$(BIN).bin: $(BIN).elf
 	$(OBJCOPY) -O binary $< $@
 
-bin: main.bin
+bin: $(BIN).bin
 
-all: libopencm3 main.bin
-
+all: libopencm3 $(BIN).bin

--- a/examples/keypad/Makefile
+++ b/examples/keypad/Makefile
@@ -4,7 +4,9 @@ sinclude ../../rules.mk
 CSRC = $(wildcard *.c)
 OBJ = $(CSRC:.c=.o)
 
-keypad.elf: $(OBJ)
+BIN = keypad
+
+$(BIN).elf: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 .PHONY: clean
@@ -15,9 +17,10 @@ clean_all:
 	-rm -rf *.o *.bin *.elf *.map *.d
 	-$(MAKE) -C libopencm3 clean
 
-%.bin: %.elf
+
+$(BIN).bin: $(BIN).elf
 	$(OBJCOPY) -O binary $< $@
 
-bin: keypad.bin
+bin: $(BIN).bin
 
-all: libopencm3 keypad.bin
+all: libopencm3 $(BIN).bin

--- a/examples/motor_constant_pwm/Makefile
+++ b/examples/motor_constant_pwm/Makefile
@@ -4,7 +4,9 @@ sinclude ../../rules.mk
 CSRC = $(wildcard *.c)
 OBJ = $(CSRC:.c=.o)
 
-main.elf: $(OBJ)
+BIN = motor_constant_pwm
+
+$(BIN).elf: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 .PHONY: clean
@@ -16,10 +18,9 @@ clean_all:
 	-$(MAKE) -C libopencm3 clean
 
 
-%.bin: %.elf
+$(BIN).bin: $(BIN).elf
 	$(OBJCOPY) -O binary $< $@
 
-bin: main.bin
+bin: $(BIN).bin
 
-all: libopencm3 main.bin
-
+all: libopencm3 $(BIN).bin

--- a/examples/motor_control/Makefile
+++ b/examples/motor_control/Makefile
@@ -1,10 +1,12 @@
 sinclude ../../rules.mk
 
 
-CSRC = motor_control.c
+CSRC = $(wildcard *.c)
 OBJ = $(CSRC:.c=.o)
 
-motor_control.elf: $(OBJ)
+BIN = motor_control
+
+$(BIN).elf: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 .PHONY: clean
@@ -16,10 +18,9 @@ clean_all:
 	-$(MAKE) -C libopencm3 clean
 
 
-%.bin: %.elf
+$(BIN).bin: $(BIN).elf
 	$(OBJCOPY) -O binary $< $@
 
-bin: motor_control.bin
+bin: $(BIN).bin
 
-all: libopencm3 motor_control.bin
-
+all: libopencm3 $(BIN).bin

--- a/examples/motor_control_encoder/Makefile
+++ b/examples/motor_control_encoder/Makefile
@@ -1,10 +1,12 @@
 sinclude ../../rules.mk
 
 
-CSRC = motor_control_with_encoder.c
+CSRC = $(wildcard *.c)
 OBJ = $(CSRC:.c=.o)
 
-motor_control_with_encoder.elf: $(OBJ)
+BIN = motor_control_encoder
+
+$(BIN).elf: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 .PHONY: clean
@@ -16,10 +18,9 @@ clean_all:
 	-$(MAKE) -C libopencm3 clean
 
 
-%.bin: %.elf
+$(BIN).bin: $(BIN).elf
 	$(OBJCOPY) -O binary $< $@
 
-bin: motor_control_with_encoder.bin
+bin: $(BIN).bin
 
-all: libopencm3 motor_control_with_encoder.bin
-
+all: libopencm3 $(BIN).bin

--- a/examples/motor_control_encoder_and_systick/Makefile
+++ b/examples/motor_control_encoder_and_systick/Makefile
@@ -1,10 +1,12 @@
 sinclude ../../rules.mk
 
 
-CSRC = motor_control_with_encoder_and_systick.c
+CSRC = $(wildcard *.c)
 OBJ = $(CSRC:.c=.o)
 
-motor_control_with_encoder_and_systick.elf: $(OBJ)
+BIN = motor_control_encoder_and_systick
+
+$(BIN).elf: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 .PHONY: clean
@@ -16,10 +18,9 @@ clean_all:
 	-$(MAKE) -C libopencm3 clean
 
 
-%.bin: %.elf
+$(BIN).bin: $(BIN).elf
 	$(OBJCOPY) -O binary $< $@
 
-bin: motor_control_with_encoder_and_systick.bin
+bin: $(BIN).bin
 
-all: libopencm3 motor_control_with_encoder_and_systick.bin
-
+all: libopencm3 $(BIN).bin

--- a/examples/motor_control_encoder_interruption/Makefile
+++ b/examples/motor_control_encoder_interruption/Makefile
@@ -4,7 +4,9 @@ sinclude ../../rules.mk
 CSRC = $(wildcard *.c)
 OBJ = $(CSRC:.c=.o)
 
-main.elf: $(OBJ)
+BIN = motor_control_encoder_interruption
+
+$(BIN).elf: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 .PHONY: clean
@@ -16,10 +18,9 @@ clean_all:
 	-$(MAKE) -C libopencm3 clean
 
 
-%.bin: %.elf
+$(BIN).bin: $(BIN).elf
 	$(OBJCOPY) -O binary $< $@
 
-bin: main.bin
+bin: $(BIN).bin
 
-all: libopencm3 main.bin
-
+all: libopencm3 $(BIN).bin

--- a/examples/motor_encoder_time_variation/Makefile
+++ b/examples/motor_encoder_time_variation/Makefile
@@ -4,7 +4,9 @@ sinclude ../../rules.mk
 CSRC = $(wildcard *.c)
 OBJ = $(CSRC:.c=.o)
 
-main.elf: $(OBJ)
+BIN = motor_encoder_time_variation
+
+$(BIN).elf: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 .PHONY: clean
@@ -16,10 +18,9 @@ clean_all:
 	-$(MAKE) -C libopencm3 clean
 
 
-%.bin: %.elf
+$(BIN).bin: $(BIN).elf
 	$(OBJCOPY) -O binary $< $@
 
-bin: main.bin
+bin: $(BIN).bin
 
-all: libopencm3 main.bin
-
+all: libopencm3 $(BIN).bin

--- a/examples/motor_rpm_mean_measurement/Makefile
+++ b/examples/motor_rpm_mean_measurement/Makefile
@@ -4,7 +4,9 @@ sinclude ../../rules.mk
 CSRC = $(wildcard *.c)
 OBJ = $(CSRC:.c=.o)
 
-main.elf: $(OBJ)
+BIN = motor_rpm_mean_measurement
+
+$(BIN).elf: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 .PHONY: clean
@@ -16,10 +18,9 @@ clean_all:
 	-$(MAKE) -C libopencm3 clean
 
 
-%.bin: %.elf
+$(BIN).bin: $(BIN).elf
 	$(OBJCOPY) -O binary $< $@
 
-bin: main.bin
+bin: $(BIN).bin
 
-all: libopencm3 main.bin
-
+all: libopencm3 $(BIN).bin

--- a/examples/motor_rpm_measurement/Makefile
+++ b/examples/motor_rpm_measurement/Makefile
@@ -4,7 +4,9 @@ sinclude ../../rules.mk
 CSRC = $(wildcard *.c)
 OBJ = $(CSRC:.c=.o)
 
-main.elf: $(OBJ)
+BIN = motor_rpm_measurement
+
+$(BIN).elf: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 .PHONY: clean
@@ -16,10 +18,9 @@ clean_all:
 	-$(MAKE) -C libopencm3 clean
 
 
-%.bin: %.elf
+$(BIN).bin: $(BIN).elf
 	$(OBJCOPY) -O binary $< $@
 
-bin: main.bin
+bin: $(BIN).bin
 
-all: libopencm3 main.bin
-
+all: libopencm3 $(BIN).bin

--- a/examples/sensor_test/Makefile
+++ b/examples/sensor_test/Makefile
@@ -1,10 +1,12 @@
 sinclude ../../rules.mk
 
 
-CSRC = sensor_test.c
+CSRC = $(wildcard *.c)
 OBJ = $(CSRC:.c=.o)
 
-sensor_test.elf: $(OBJ)
+BIN = sensor_test
+
+$(BIN).elf: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 .PHONY: clean
@@ -16,10 +18,9 @@ clean_all:
 	-$(MAKE) -C libopencm3 clean
 
 
-%.bin: %.elf
+$(BIN).bin: $(BIN).elf
 	$(OBJCOPY) -O binary $< $@
 
-bin: sensor_test.bin
+bin: $(BIN).bin
 
-all: libopencm3 sensor_test.bin
-
+all: libopencm3 $(BIN).bin

--- a/examples/servo/Makefile
+++ b/examples/servo/Makefile
@@ -1,10 +1,12 @@
 sinclude ../../rules.mk
 
 
-CSRC = servo.c
+CSRC = $(wildcard *.c)
 OBJ = $(CSRC:.c=.o)
 
-servo.elf: $(OBJ)
+BIN = servo
+
+$(BIN).elf: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 .PHONY: clean
@@ -16,9 +18,9 @@ clean_all:
 	-$(MAKE) -C libopencm3 clean
 
 
-%.bin: %.elf
+$(BIN).bin: $(BIN).elf
 	$(OBJCOPY) -O binary $< $@
 
-bin: servo.bin
+bin: $(BIN).bin
 
-all: libopencm3 servo.bin
+all: libopencm3 $(BIN).bin

--- a/examples/systick/Makefile
+++ b/examples/systick/Makefile
@@ -1,10 +1,12 @@
 sinclude ../../rules.mk
 
 
-CSRC = systick.c
+CSRC = $(wildcard *.c)
 OBJ = $(CSRC:.c=.o)
 
-systick.elf: $(OBJ)
+BIN = systick
+
+$(BIN).elf: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 .PHONY: clean
@@ -16,10 +18,9 @@ clean_all:
 	-$(MAKE) -C libopencm3 clean
 
 
-%.bin: %.elf
+$(BIN).bin: $(BIN).elf
 	$(OBJCOPY) -O binary $< $@
 
-bin: systick.bin
+bin: $(BIN).bin
 
-all: libopencm3 systick.bin
-
+all: libopencm3 $(BIN).bin

--- a/examples/timer1_pwms/Makefile
+++ b/examples/timer1_pwms/Makefile
@@ -1,10 +1,12 @@
 sinclude ../../rules.mk
 
 
-CSRC = timer1_pwms.c
+CSRC = $(wildcard *.c)
 OBJ = $(CSRC:.c=.o)
 
-timer1_pwms.elf: $(OBJ)
+BIN = timer1_pwms
+
+$(BIN).elf: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 .PHONY: clean
@@ -16,10 +18,9 @@ clean_all:
 	-$(MAKE) -C libopencm3 clean
 
 
-%.bin: %.elf
+$(BIN).bin: $(BIN).elf
 	$(OBJCOPY) -O binary $< $@
 
-bin: timer1_pwms.bin
+bin: $(BIN).bin
 
-all: libopencm3 timer1_pwms.bin
-
+all: libopencm3 $(BIN).bin

--- a/examples/timer4_pwms/Makefile
+++ b/examples/timer4_pwms/Makefile
@@ -1,10 +1,12 @@
 sinclude ../../rules.mk
 
 
-CSRC = timer4_pwms.c
+CSRC = $(wildcard *.c)
 OBJ = $(CSRC:.c=.o)
 
-timer4_pwms.elf: $(OBJ)
+BIN = timer4_pwms
+
+$(BIN).elf: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 .PHONY: clean
@@ -16,10 +18,9 @@ clean_all:
 	-$(MAKE) -C libopencm3 clean
 
 
-%.bin: %.elf
+$(BIN).bin: $(BIN).elf
 	$(OBJCOPY) -O binary $< $@
 
-bin: timer4_pwms.bin
+bin: $(BIN).bin
 
-all: libopencm3 timer4_pwms.bin
-
+all: libopencm3 $(BIN).bin

--- a/examples/usart_cam/Makefile
+++ b/examples/usart_cam/Makefile
@@ -4,7 +4,9 @@ sinclude ../../rules.mk
 CSRC = $(wildcard *.c)
 OBJ = $(CSRC:.c=.o)
 
-usart_cam_test.elf: $(OBJ)
+BIN = usart_cam_test
+
+$(BIN).elf: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 .PHONY: clean
@@ -16,10 +18,9 @@ clean_all:
 	-$(MAKE) -C libopencm3 clean
 
 
-%.bin: %.elf
+$(BIN).bin: $(BIN).elf
 	$(OBJCOPY) -O binary $< $@
 
-bin: usart_cam_test.bin
+bin: $(BIN).bin
 
-all: libopencm3 usart_cam_test.bin
-
+all: libopencm3 $(BIN).bin

--- a/examples/usart_rxtx_test/Makefile
+++ b/examples/usart_rxtx_test/Makefile
@@ -1,10 +1,12 @@
 sinclude ../../rules.mk
 
 
-CSRC = usart_test.c
+CSRC = $(wildcard *.c)
 OBJ = $(CSRC:.c=.o)
 
-usart_test.elf: $(OBJ)
+BIN = usart_rxtx_test
+
+$(BIN).elf: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 .PHONY: clean
@@ -16,10 +18,9 @@ clean_all:
 	-$(MAKE) -C libopencm3 clean
 
 
-%.bin: %.elf
+$(BIN).bin: $(BIN).elf
 	$(OBJCOPY) -O binary $< $@
 
-bin: usart_test.bin
+bin: $(BIN).bin
 
-all: libopencm3 usart_test.bin
-
+all: libopencm3 $(BIN).bin

--- a/examples/usart_tx_test/Makefile
+++ b/examples/usart_tx_test/Makefile
@@ -1,10 +1,12 @@
 sinclude ../../rules.mk
 
 
-CSRC = usart_test.c
+CSRC = $(wildcard *.c)
 OBJ = $(CSRC:.c=.o)
 
-usart_test.elf: $(OBJ)
+BIN = usart_tx_test
+
+$(BIN).elf: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 .PHONY: clean
@@ -16,10 +18,9 @@ clean_all:
 	-$(MAKE) -C libopencm3 clean
 
 
-%.bin: %.elf
+$(BIN).bin: $(BIN).elf
 	$(OBJCOPY) -O binary $< $@
 
-bin: usart_test.bin
+bin: $(BIN).bin
 
-all: libopencm3 usart_test.bin
-
+all: libopencm3 $(BIN).bin

--- a/examples/vbatt_adc/Makefile
+++ b/examples/vbatt_adc/Makefile
@@ -4,7 +4,9 @@ sinclude ../../rules.mk
 CSRC = $(wildcard *.c)
 OBJ = $(CSRC:.c=.o)
 
-sensor_test.elf: $(OBJ)
+BIN = vbatt_adc
+
+$(BIN).elf: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 .PHONY: clean
@@ -16,9 +18,9 @@ clean_all:
 	-$(MAKE) -C libopencm3 clean
 
 
-%.bin: %.elf
+$(BIN).bin: $(BIN).elf
 	$(OBJCOPY) -O binary $< $@
 
-bin: sensor_test.bin
+bin: $(BIN).bin
 
-all: libopencm3 sensor_test.bin
+all: libopencm3 $(BIN).bin


### PR DESCRIPTION
Use **make** (without target) or **make help** to show information about the available targets.

**make build_image** generates the Docker image for development.

**make buga_fw** builds the firmware
**make buga_fw_flash PORT=/dev/ttyUSB0** flashes the previously compiled firwmare in the board connected to the specified port. If no port is specified, ttyUSB0 is used.

The Makefile includes targets for every example in the examples/ folder. Each example has a target with the form examples/<example_name> where example_name  is the name of the folder where the example is located. There is also a target with the form examples/<example_name>_flash that loads the corresponding example to the board. As in the previous case, the variable PORT can be used to specify the serial port used to communicate with the board. bluepill_test example provides the following targets (the scheme is followed by every single example):
- examples/bluepill_test
- examples/bluepill_test_flash